### PR TITLE
safety guards for buffer sizes

### DIFF
--- a/src/main/java/com/rtbhouse/model/natives/NeuralNetworkNativeOps.java
+++ b/src/main/java/com/rtbhouse/model/natives/NeuralNetworkNativeOps.java
@@ -2,13 +2,18 @@ package com.rtbhouse.model.natives;
 
 import java.nio.FloatBuffer;
 
+import org.bytedeco.javacpp.annotation.Cast;
+import org.bytedeco.javacpp.annotation.Const;
+import org.bytedeco.javacpp.annotation.MemberGetter;
+import org.bytedeco.javacpp.annotation.Name;
 import org.bytedeco.javacpp.annotation.Platform;
+import org.bytedeco.javacpp.annotation.ValueGetter;
 
 import com.github.fommil.jni.JniLoader;
 
 /**
  * <p>
- * Utility class with few operations useful when dealing with neural networks. Operations are implemented on native side
+ * Utility class with few operations useful when dealing with neural networks. Operations are implemented at native side
  * with BLAS behind the scenes.
  * </p>
  * Supports only single precision floating point numbers. Both heap and direct float buffers are supported but
@@ -19,226 +24,300 @@ import com.github.fommil.jni.JniLoader;
 @Platform(include = "NeuralNetworkNativeOps.h", compiler = "fastfpu")
 public final class NeuralNetworkNativeOps {
 
-    public static int TRANSPOSE = 0;
-    public static int NO_TRANSPOSE = 1;
-
     static {
         JniLoader.load("com/rtbhouse/model/natives/libjniNeuralNetworkNativeOps.so");
+    }
+
+    private static native @MemberGetter @Const int TRANSPOSE();
+
+    private static native @ValueGetter @Const int NO_TRANSPOSE();
+
+    public enum Trans {
+        TRANSPOSE(TRANSPOSE()), NO_TRANSPOSE(NO_TRANSPOSE());
+
+        private int value;
+
+        Trans(int value) {
+            this.value = value;
+        }
+
+        private int value() {
+            return value;
+        }
     }
 
     private NeuralNetworkNativeOps() {
     }
 
     /**
-     * <p>
-     * Rectified linear unit (ReLU) function. Performs the operation in-place.
-     * </p>
-     * <p>
-     * All input vector elements are transformed with function:
-     * </p>
-     * 
+     * In-place applies the rectified linear unit (ReLU) function to the first {@code endExclusive} input elements:
+     *
      * <pre>
-     * f(x) = max(0, x)
+     * ReLU(x) = max(0, x)
      * </pre>
      *
      * @param inOut
      *            input/output vector (read write)
-     * @param size
-     *            size of vector
+     * @param endExclusive
+     *            index immediately past the last index to process
      */
-    public static native void ReLU(FloatBuffer inOut, int size);
+    public static void ReLU(FloatBuffer inOut, int endExclusive) {
+        if (endExclusive > inOut.limit() || endExclusive < 0) {
+            throw new IndexOutOfBoundsException();
+        }
 
-    public static void ReLU(FloatBuffer inOut) {
-        ReLU(inOut, inOut.limit());
+        nativeReLU(inOut, endExclusive);
     }
 
     /**
-     * <p>
-     * Exponential linear unit (ELU) function. Performs the operation in-place.
-     * </p>
-     * <p>
-     * All input vector elements are transformed with function:
-     * </p>
-     * 
+     * Applies the {@link NeuralNetworkNativeOps#ReLU} for whole input vector in-place.
+     *
+     * @param inOut
+     *            input/output vector (read write)
+     */
+    public static void ReLU(FloatBuffer inOut) {
+        nativeReLU(inOut, inOut.limit());
+    }
+
+    private static native @Name("ReLU") void nativeReLU(FloatBuffer inOut, int endExclusive);
+
+    /**
+     * In-place applies the exponential linear unit (ELU) function to the first {@code endExclusive} input vector
+     * elements:
+     *
      * <pre>
-     * f(x) = max(0, x) + min(0, alpha * (exp(x) - 1))
+     * ELU(x) = max(0, x) + min(0, alpha * (exp(x) - 1))
      * </pre>
      *
      * @param inOut
      *            input/output vector (read write)
-     * @param size
-     *            size of vector
+     * @param endExclusive
+     *            index immediately past the last index to process
      * @param alpha
      *            varies the convergence value of the exponential function below zero
      */
-    public static native void ELU(FloatBuffer inOut, int size, float alpha);
+    public static void ELU(FloatBuffer inOut, int endExclusive, float alpha) {
+        if (endExclusive > inOut.limit() || endExclusive < 0) {
+            throw new IndexOutOfBoundsException();
+        }
 
-    public static void ELU(FloatBuffer inOut, float alpha) {
-        ELU(inOut, inOut.limit(), alpha);
+        nativeELU(inOut, endExclusive, alpha);
     }
 
     /**
-     * <p>
-     * Float matrix-vector multiplication. Destination memory is read and overwritten. Other buffers are read-only.
-     * </p>
-     * <p>
-     * Operation:
-     * </p>
-     * 
+     * Applies the {@link NeuralNetworkNativeOps#ELU} for whole input vector in-place.
+     *
+     * @param inOut
+     *            input/output vector (read write)
+     * @param alpha
+     *            varies the convergence value of the exponential function below zero
+     */
+    public static void ELU(FloatBuffer inOut, float alpha) {
+        nativeELU(inOut, inOut.limit(), alpha);
+    }
+
+    private static native @Name("ELU") void nativeELU(FloatBuffer inOut, int endExclusive, float alpha);
+
+    /**
+     * Applies a float matrix-vector multiplication with accumulation (gemv):
+     *
      * <pre>
      * y = A * x + y
      * </pre>
      *
+     * Destination memory is read and overwritten. Other buffers are read-only.
+     *
      * @param A
-     *            input 2d matrix with logical dimensions: {@code ySize} x {@code xSize} (ro)
+     *            input matrix with logical dimensions: {@code n} x {@code m} (ro)
      * @param x
      *            input vector (ro)
      * @param y
      *            input/output vector (rw)
-     * @param xSize
-     *            size of input vector
-     * @param ySize
-     *            size of input/output vector
+     * @param m
+     *            index immediately past the last index to process in {@code x} and number of logical columns in
+     *            {@code A}
+     * @param n
+     *            index immediately past the last index to process in {@code y} and number of logical rows in {@code A}
      * @see <a
      *      href=
-     *      "http://www.netlib.org/lapack/explore-html/d6/d30/group__single__blas__level2.html#gafc92361b74c6d41c7e5afa0aa5d13ec9"
+     *      "http://www.netlib.org/lapack/explore-html/d6/d30/group__single__blas__level2_gafc92361b74c6d41c7e5afa0aa5d13ec9"
      *      >sgemv @ netlib lapack docs</a>
      */
-    public static native void gemv(FloatBuffer A, FloatBuffer x, FloatBuffer y, int xSize, int ySize);
+    public static void gemv(FloatBuffer A, FloatBuffer x, FloatBuffer y, int m, int n) {
+        if (m > x.limit() || n > y.limit() || m * n > A.limit() || m < 0 || n < 0) {
+            throw new IndexOutOfBoundsException();
+        }
 
-    /**
-     * "Sizeless" version of {@link NeuralNetworkNativeOps#gemv}.
-     */
-    public static void gemv(FloatBuffer A, FloatBuffer x, FloatBuffer y) {
-        gemv(A, x, y, x.limit(), y.limit());
+        nativeGemv(A, x, y, m, n);
     }
 
     /**
-     * <p>
-     * Float matrix-matrix multiplication. Destination memory is read and overwritten.
-     * </p>
-     * <p>
-     * Operation:
-     * </p>
+     * Applies the {@link NeuralNetworkNativeOps#gemv} to the whole incoming data in-place.
+     * 
+     * @param A
+     *            input matrix with logical dimensions: {@code y.limit()} x {@code x.limit()} (ro)
+     * @param x
+     *            input vector (ro)
+     * @param y
+     *            input/output vector (rw)
+     */
+    public static void gemv(FloatBuffer A, FloatBuffer x, FloatBuffer y) {
+        if (x.limit() * y.limit() != A.limit()) {
+            throw new IllegalArgumentException();
+        }
+
+        nativeGemv(A, x, y, x.limit(), y.limit());
+    }
+
+    private static native @Name("gemv") void nativeGemv(FloatBuffer A, FloatBuffer x, FloatBuffer y, int xSize,
+            int ySize);
+
+    /**
+     * Applies a float matrix-matrix multiplication with accumulation (gemm):
      * 
      * <pre>
      * Y = A * B + Y
      * </pre>
      *
+     * Destination memory is read and overwritten. Other buffers are read-only.
+     * 
      * @param A
-     *            input k x m matrix
+     *            input matrix with logical dimensions: {@code m} x {@code k} (ro)
      * @param B
-     *            input m x n matrix
+     *            input matrix with logical dimensions: {@code k} x {@code n} (ro)
      * @param Y
-     *            input/output k x n matrix
+     *            input/output matrix with logical dimensions: {@code m} x {@code n} (rw)
+     * @param m
+     *            number of logical rows in {@code A} and {@code Y}
+     * @param n
+     *            number of logical columns in {@code B} and {@code Y}
+     * @param k
+     *            number of logical columns in {@code A} and logical rows in {@code B}
      * @see <a href=
      *      "http://www.netlib.org/lapack/explore-html/db/dc9/group__single__blas__level3.html#gafe51bacb54592ff5de056acabd83c260"
      *      >sgemm @ netlib lapack docs</a>
      */
-    public static native void gemm(FloatBuffer A, FloatBuffer B, FloatBuffer Y, int k, int m, int n);
+    public static void gemm(FloatBuffer A, FloatBuffer B, FloatBuffer Y, int m, int n, int k) {
+        if (m * k > A.limit() || k * n > B.limit() || m * n > Y.limit() || k < 0 || m < 0 || n < 0) {
+            throw new IndexOutOfBoundsException();
+        }
 
-    /**
-     * "Sizeless" version of {@link NeuralNetworkNativeOps#gemm}.
-     */
-    public static void gemm(FloatBuffer A, FloatBuffer B, FloatBuffer Y) {
-        gemm(A, B, Y,
-                (int) Math.sqrt(A.limit() * Y.limit() / B.limit()),
-                (int) Math.sqrt(A.limit() * B.limit() / Y.limit()),
-                (int) Math.sqrt(B.limit() * Y.limit() / A.limit()));
+        nativeGemm(A, B, Y, m, n, k);
     }
 
+    private static native @Name("gemm") void nativeGemm(FloatBuffer A, FloatBuffer B, FloatBuffer Y, int m, int n, int k);
+
     /**
-     * <p>
-     * Forward operation for a single linear neural-network layer: Output contents is discarded and overwritten. Other
-     * buffers are read-only.
-     * </p>
-     * 
+     * Applies a linear transformation to the incoming data:
+     *
      * <pre>
      * output = weights * input + biases
      * </pre>
-     *
-     * @param transpose
+     * 
+     * Output contents are discarded and overwritten. Other buffers are read-only.
+     * 
+     * @param transposeWeights
      *            whether {@code weights} should be transposed before multiplication
      * @param weights
-     *            weights 2d matrix with logical dimensions: {@code outputSize} x {@code inputSize} (after optional
-     *            transposition) (ro)
+     *            weights matrix with logical dimensions: {@code inputSize} x {@code outputSize} if
+     *            {@code transposeWeights == TRANSPOSE}, reversed otherwise (ro)
      * @param biases
-     *            bias vector with size {@code outputSize} (ro)
+     *            biases vector (ro)
      * @param input
-     *            input vector with size {@code inputSize} (ro)
+     *            input vector (ro)
      * @param output
-     *            output vector with size {@code outputSize} (write only)
+     *            output vector (write only)
      * @param inputSize
-     *            size of input
+     *            index immediately past the last index to process in {@code input} and number of logical rows in
+     *            {@code weights} if {@code transposeWeights == TRANSPOSE}, columns otherwise.
      * @param outputSize
-     *            size of output
+     *            index immediately past the last index to process in {@code output} and {@code biases}; also number of
+     *            logical columns in {@code weights} if {@code transposeWeights == TRANSPOSE}, rows otherwise.
      */
-    public static native void linearForward(int transpose, FloatBuffer weights, FloatBuffer biases,
-            FloatBuffer input, FloatBuffer output, int inputSize, int outputSize);
+    public static void linearForward(Trans transposeWeights, FloatBuffer weights, FloatBuffer biases,
+            FloatBuffer input, FloatBuffer output, int inputSize, int outputSize) {
+
+        if (inputSize > input.limit() || outputSize > output.limit() || outputSize > biases.limit()
+                || outputSize * inputSize > weights.limit() || inputSize < 0 || outputSize < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        nativeLinearForward(transposeWeights.value(), weights, biases, input, output, inputSize, outputSize);
+    }
 
     /**
-     * <p>
-     * Forward operation for a single linear neural-network layer: Output contents is discarded and overwritten. Other
-     * buffers are read-only.
-     * </p>
+     * Applies the {@link NeuralNetworkNativeOps#linearForward} to the whole incoming data in-place.
      * 
+     * @param transposeWeights
+     *            whether {@code weights} should be transposed before multiplication
+     * @param weights
+     *            weights matrix with logical dimensions: {@code input.limit()} x {@code output.limit()} if
+     *            {@code transposeWeights == TRANSPOSE}, reversed otherwise (ro)
+     * @param biases
+     *            bias vector with size {@code output.limit()} (ro)
+     * @param input
+     *            input vector (ro)
+     * @param output
+     *            output vector (write only)
+     */
+    public static void linearForward(Trans transposeWeights, FloatBuffer weights, FloatBuffer biases,
+            FloatBuffer input, FloatBuffer output) {
+
+        if (input.limit() * output.limit() != weights.limit() || output.limit() != biases.limit()) {
+            throw new IllegalArgumentException();
+        }
+
+        nativeLinearForward(transposeWeights.value(), weights, biases, input, output, input.limit(), output.limit());
+    }
+
+    private static native @Name("linearForward") void nativeLinearForward(
+            @Cast("NNNOTranspose") int transposeWeights, FloatBuffer weights, FloatBuffer biases, FloatBuffer input,
+            FloatBuffer output, int inputSize, int outputSize);
+
+    /**
+     * Applies a linear transformation to the incoming data:
+     *
      * <pre>
      * output = weights * input + biases
      * </pre>
      *
-     * @param transpose
-     *            whether {@code weights} should be transposed before multiplication
-     * @param weights
-     *            weights 2d matrix with logical dimensions: {@code outputSize} x {@code inputSize} (after optional
-     *            transposition) (ro)
-     * @param biases
-     *            bias vector with size {@code outputSize} (ro)
-     * @param input
-     *            input vector with size {@code inputSize} (ro)
-     * @param output
-     *            output vector with size {@code outputSize} (write only)
-     */
-    public static void linearForward(int transpose, FloatBuffer weights, FloatBuffer biases, FloatBuffer input,
-            FloatBuffer output) {
-        linearForward(transpose, weights, biases, input, output, input.limit(), output.limit());
-    }
-
-    /**
-     * <p>
-     * Forward operation for a single linear neural-network layer: Output contents is discarded and overwritten. Other
-     * buffers are read-only.
-     * </p>
-     * 
-     * <pre>
-     * output = input * weights + biases
-     * </pre>
+     * Output contents are discarded and overwritten. Other buffers are read-only.
      *
-     * @param transpose
+     * @param transposeWeights
      *            whether {@code weights} should be transposed before multiplication
      * @param weights
-     *            weights 2d matrix with logical dimensions: {@code inputRowSize} x {@code outputRowSize} (after
-     *            optional transposition)(ro)
+     *            weights matrix with logical dimensions: {@code outputRowSize} x {@code inputRowSize} if
+     *            {@code transposeWeights == TRANSPOSE}, reversed otherwise (ro)
      * @param biases
      *            bias vector with size {@code outputRowSize} (ro)
      * @param input
-     *            input matrix with size {@code inputRowSize} x {@code batchSize} (ro). Values from one row should
-     *            occupy consecutive memory
-     *            cells
+     *            input matrix with size {@code batchSize} x {@code inputRowSize}; values from one row should
+     *            occupy consecutive memory cells (ro)
      * @param output
-     *            output where matrix with size {@code outputSize} x {@code batchSize} will be written (write only)
+     *            output matrix with size {@code batchSize} x {@code outputRowSize} (write only)
      * @param inputRowSize
-     *            number of floats in each row of the input
+     *            number of logical columns in {@code input} and logical columns in {@code weights} if
+     *            {@code transposeWeights == TRANSPOSE}, rows otherwise
      * @param outputRowSize
-     *            number of floats in each row of the output
+     *            number of logical columns in {@code output} and logical rows in {@code weights} if
+     *            {@code transposeWeights == TRANSPOSE}, columns otherwise
      * @param batchSize
-     *            number of rows in input, thus in output as well
+     *            number of logical rows in {@code input} and {@code output} to process
      */
-    public static native void linearBatchForward(int transpose, FloatBuffer weights, FloatBuffer biases,
-            FloatBuffer input, FloatBuffer output, int inputRowSize, int outputRowSize, int batchSize);
+    public static void linearBatchForward(Trans transposeWeights, FloatBuffer weights, FloatBuffer biases,
+            FloatBuffer input, FloatBuffer output, int inputRowSize, int outputRowSize, int batchSize) {
 
-    /**
-     * Performs native side BLAS sgemv operation and checks if results are correct.
-     * Used only for the module development purposes, doesn't make part of a regular usage pattern.
-     */
-    static native int test();
+        if (inputRowSize * batchSize > input.limit() || outputRowSize * batchSize > output.limit()
+                || outputRowSize > biases.limit() || inputRowSize * outputRowSize > weights.limit()
+                || outputRowSize < 0 || inputRowSize < 0 || batchSize < 0) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        nativeLinearBatchForward(transposeWeights.value(),
+                weights, biases, input, output, inputRowSize, outputRowSize, batchSize);
+    }
+
+    private static native @Name("linearBatchForward") void nativeLinearBatchForward(
+            @Cast("NNNOTranspose") int transposeWeights, FloatBuffer weights, FloatBuffer biases, FloatBuffer input,
+            FloatBuffer output, int inputRowSize, int outputRowSize, int batchSize);
 }

--- a/src/main/resources/com/rtbhouse/model/natives/NeuralNetworkNativeOps.h
+++ b/src/main/resources/com/rtbhouse/model/natives/NeuralNetworkNativeOps.h
@@ -2,35 +2,39 @@
 #include <cblas.h>
 #include <math.h>
 
-#define TRANSPOSE 0
-#define NO_TRANSPOSE 1
+enum NNNOTranspose {
+    TRANSPOSE = 0,
+    NO_TRANSPOSE = 1
+};
 
-static const float ALPHA = 1.0, BETA = 1.0, ONE = 1.0;
-static const int X_INC = 1, Y_INC = 1;
+static const float ALPHA = 1.0;
+static const float BETA = 1.0;
+static const float ONE = 1.0;
+static const int X_INC = 1;
+static const int Y_INC = 1;
 
 /**
- * Rectified linear unit (ReLU) function. Performs the operation in-place.
+ * In-place applies the rectified linear unit (ReLU) function to the first `endExclusive` input vector elements:
  *
- * All input vector elements are transformed with the function:
- *   f(x) = max(0, x)
+ *   ReLU(x) = max(0, x)
  */
-inline void ReLU(float *inOut, const int size) {
+inline void ReLU(float *inOut, const int endExclusive) {
     int i;
-    for(i=0; i<size; i++) {
-        inOut[i] = inOut[i] < 0 ? 0 : inOut[i];
+    for(i=0; i < endExclusive; i++) {
+        if (inOut[i] < 0) {
+            inOut[i] = 0;
+        }
     }
 }
 
 /**
- * Exponential linear unit (ELU) function. Performs the operation in-place.
+ * In-place applies the exponential linear unit (ELU) function to the first `endExclusive` input vector elements:
  *
- * All input vector elements are transformed with the function:
- *
- *   f(x) = max(0, x) + min(0, alpha * (exp(x) - 1))
+ *   ELU(x) = max(0, x) + min(0, alpha * (exp(x) - 1))
  */
-inline void ELU(float *inOut, const int size, const float alpha) {
+inline void ELU(float *inOut, const int endExclusive, const float alpha) {
     int i;
-    for(i=0; i < size; i++) {
+    for(i=0; i < endExclusive; i++) {
         if (inOut[i] < 0) {
             inOut[i] = (expf(inOut[i]) - 1) * alpha;
         }
@@ -38,107 +42,77 @@ inline void ELU(float *inOut, const int size, const float alpha) {
 }
 
 /**
- * Float matrix-vector multiplication. Destination memory is read and overwritten.
+ * Applies a float matrix-vector multiplication with accumulation (gemv).
  *
- *  A - input matrix
- *  x - input vector
- *  y - input/output vector
- *
- * Operation:
  *   y = A * x + y
  *
- * @see http://www.netlib.org/lapack/explore-html/d6/d30/group__single__blas__level2.html#gafc92361b74c6d41c7e5afa0aa5d13ec9
+ * Destination memory is read and overwritten. Other buffers are read-only.
+ *
+ *  A - input matrix        (n x m)
+ *  x - input vector        (    m)
+ *  y - input/output vector (n    )
+ *
+ * @see http://www.netlib.org/lapack/explore-html/d6/d30/group__single__blas__level2_gafc92361b74c6d41c7e5afa0aa5d13ec9
  */
-inline void gemv(const float *A, const float *x, float *y, const int xSize, const int ySize) {
-    cblas_sgemv( CblasRowMajor, CblasNoTrans, ySize, xSize, ALPHA, A, xSize, x, X_INC, BETA, y, Y_INC);
+inline void gemv(const float *A, const float *x, float *y, const int m, const int n) {
+    cblas_sgemv( CblasRowMajor, CblasNoTrans, n, m, ALPHA, A, m, x, X_INC, BETA, y, Y_INC);
 }
 
 
 /**
- * Float matrix-matrix multiplication. Destination memory is read and overwritten.
+ * Applies a float matrix-matrix multiplication with accumulation (gemm):
  *
- *  A - input        m x k     matrix
- *  B - input            k x n matrix
- *  Y - input/output m   x   n matrix
- *
- * Operation:
  *   Y = A * B + Y
  *
+ *  A - input matrix        (m x k    )
+ *  B - input matrix        (    k x n)
+ *  Y - input/output matrix (m   x   n)
+ *
+ * @see http://www.netlib.org/lapack/explore-html/db/dc9/group__single__blas__level3_gafe51bacb54592ff5de056acabd83c260
  */
 inline void gemm(const float *A, const float *B, float *Y, const int m, const int n, const int k) {
     cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, ONE, A, k, B, n, ONE, Y, n);
 }
 
 /**
- * Forward operation for a single linear neural-network layer
+ * Forward operation for a single linear neural-network layer:
  *
- * Operation:
  *   output = weights(T) * input + biases
  *
  * (T) - optionally transposed
  */
-inline void linearForward(int transposeWeights, const float *weights, const float *biases, const float *input, float *output,
-        const int inputSize, const int outputSize) {
+inline void linearForward(const NNNOTranspose transposeWeights, const float *weights, const float *biases,
+        const float *input, float *output, const int inputSize, const int outputSize) {
 
     memcpy(output, biases, outputSize * sizeof(float));
     if (transposeWeights == TRANSPOSE) {
-        cblas_sgemv( CblasRowMajor, CblasTrans, inputSize, outputSize, ALPHA, weights, outputSize, input, X_INC, BETA, output, Y_INC);
+        cblas_sgemv( CblasRowMajor, CblasTrans,
+            inputSize, outputSize, ALPHA, weights, outputSize, input, X_INC, BETA, output, Y_INC);
     } else {
-        cblas_sgemv( CblasRowMajor, CblasNoTrans, outputSize, inputSize, ALPHA, weights, inputSize, input, X_INC, BETA, output, Y_INC);
+        cblas_sgemv( CblasRowMajor, CblasNoTrans,
+            outputSize, inputSize, ALPHA, weights, inputSize, input, X_INC, BETA, output, Y_INC);
     }
 }
 
 /**
- * Forward operation for a single linear neural-network layer. Each input row should occupy consecutive memory cells.
+ * Forward operation for a single linear neural-network layer. Each input row must occupy consecutive memory cells:
  *
- * Operation:
  *   output = input * weights(T) + biases
  *
  * (T) - optionally transposed
  */
-inline void linearBatchForward(int transposeWeights, const float *weights, const float *biases, const float *input, float *output,
-        const int inputRowSize, const int outputRowSize, const int batchSize) {
+inline void linearBatchForward(const NNNOTranspose transposeWeights, const float *weights, const float *biases,
+        const float *input, float *output, const int inputRowSize, const int outputRowSize, const int batchSize) {
     float *tmp = output;
-    for(int i=0; i<batchSize; i++) {
+    for(int i=0; i < batchSize; i++) {
         memcpy(tmp, biases, outputRowSize * sizeof(float));
         tmp += outputRowSize;
     }
     if (transposeWeights == TRANSPOSE) {
-        cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasTrans, batchSize, outputRowSize, inputRowSize, ONE, input, inputRowSize, weights, inputRowSize, ONE, output, outputRowSize);
+        cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasTrans, batchSize, outputRowSize, inputRowSize, ONE,
+            input, inputRowSize, weights, inputRowSize, ONE, output, outputRowSize);
     } else {
-        cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasNoTrans, batchSize, outputRowSize, inputRowSize, ONE, input, inputRowSize, weights, outputRowSize, ONE, output, outputRowSize);
+        cblas_sgemm( CblasRowMajor, CblasNoTrans, CblasNoTrans, batchSize, outputRowSize, inputRowSize, ONE,
+            input, inputRowSize, weights, outputRowSize, ONE, output, outputRowSize);
     }
-}
-
-///////////////
-// T E S T S //
-///////////////
-void pr(const char *name, const float *arr, const int size) {
-    int i;
-    printf(">>     %s = [", name);
-    for(i=0; i<size; i++) {
-        printf("%5.2f%s", arr[i], i<size-1 ? ", " : " ]");
-    }
-    printf("\n");
-}
-
-int test() {
-    const int xS = 2, yS = 3;
-    float A[] = { 1, 2,
-                  3, 4,
-                  2, 3};
-    float x[] = {-1, 3};
-    float y[] = {3, 2, 1};
-    pr("A", A, xS * yS);
-    pr("x", x, xS);
-    pr("y before", y, yS);
-    gemv(A, x, y, xS, yS);
-    //cblas_sgemv ( CblasRowMajor, CblasNoTrans, yS, xS, 1, &A[1], 3, x, 1, 1, y, 1 );
-    pr("y after", y, yS);
-    if (y[0] != 8 || y[1] != 11 || y[2] != 8 ) {
-        printf("gBLAS sgemv test failed: y should be [8,11,8]\n");
-        return -1;
-    }
-    printf("gBLAS sgemv test OK\n");
-    return 0;
 }

--- a/src/test/java/com/rtbhouse/model/natives/NNNOBenchmark.java
+++ b/src/test/java/com/rtbhouse/model/natives/NNNOBenchmark.java
@@ -1,6 +1,6 @@
 package com.rtbhouse.model.natives;
 
-import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.NO_TRANSPOSE;
+import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.Trans.NO_TRANSPOSE;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/src/test/java/com/rtbhouse/model/natives/NeuralNetworkNativeOpsTest.java
+++ b/src/test/java/com/rtbhouse/model/natives/NeuralNetworkNativeOpsTest.java
@@ -1,13 +1,14 @@
 package com.rtbhouse.model.natives;
 
-import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.NO_TRANSPOSE;
-import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.ReLU;
 import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.ELU;
-import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.TRANSPOSE;
+import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.ReLU;
+import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.Trans.NO_TRANSPOSE;
+import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.Trans.TRANSPOSE;
+import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.gemm;
 import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.gemv;
+import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.linearBatchForward;
 import static com.rtbhouse.model.natives.NeuralNetworkNativeOps.linearForward;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -18,20 +19,23 @@ import org.junit.Test;
 public class NeuralNetworkNativeOpsTest {
     static final float MAX_ERROR = 1e-6f;
 
-    private final FloatBuffer heapA = FloatBuffer.wrap(new float[] { 1f / 3, 2, 3, 4, 2, 3 });
-    private final FloatBuffer heapX = FloatBuffer.wrap(new float[] { -1, 3 });
-    private final FloatBuffer heapY = FloatBuffer.wrap(new float[] { 3, 2, 1f / 3 });
-    private final FloatBuffer heapOutput = FloatBuffer.wrap(new float[] { -1, -1, -1 });
+    private final FloatBuffer heapA = matrixFB(1f / 3, 2, 3, 4, 2, 3);
+    private final FloatBuffer heapX = matrixFB(-1, 3);
+    private final FloatBuffer heapY = matrixFB(3, 2, 1f / 3);
+    private final FloatBuffer heapOutput = matrixFB(-1, -1, -1);
 
     private final FloatBuffer directA = allocateDirectFloatBufferOf(1f / 3, 2, 3, 4, 2, 3);
     private final FloatBuffer directX = allocateDirectFloatBufferOf(-1, 3);
     private final FloatBuffer directY = allocateDirectFloatBufferOf(3, 2, 1f / 3);
     private final FloatBuffer directOutput = allocateDirectFloatBufferOf(-1, -1, -1);
 
-    private final float[] expectedReLUx = new float[] { 0, 3 };
-    private float[] expectedAbyXplusY = new float[] { 8f + (2f / 3), 11, 7f + (1f / 3) };
+    private final float[] expectedReLUx = matrix(0, 3);
+    private final float[] expectedReLUFirstTwoOutput = matrix(0, 0, -1);
     private final float[] expectedELUx2 = matrix(2 / (float) Math.E - 2, 3);
     private final float[] expectedELUx2FirstOutput = matrix(2 / (float) Math.E - 2, -1, -1);
+    private final float[] expectedAbyXplusY = matrix(8f + (2f / 3), 11, 7f + (1f / 3));
+    private final float[] expectedTransposedAbyXplusY = matrix(14f + (2f / 3), 6, 6f + (1f / 3));
+    private final float[] expectedAbyFirstValXplusY = matrix(2f + (2f / 3), 0, -3 + (1f / 3));
 
     private static FloatBuffer allocateDirectFloatBufferOf(float... src) {
         return ByteBuffer
@@ -49,12 +53,15 @@ public class NeuralNetworkNativeOpsTest {
     }
 
     @Test
-    public void nativeTestInvoke() {
-        assertEquals(0, NeuralNetworkNativeOps.test());
+    public void shouldReLUwithHeapFloatBuffers() {
+        // when
+        ReLU(heapOutput, 2);
+        // then
+        assertArrayEquals(expectedReLUFirstTwoOutput, heapOutput.array(), MAX_ERROR);
     }
 
     @Test
-    public void testHeapFloatBuffersReLU() {
+    public void shouldReLUwithHeapFloatBuffersSizeless() {
         // when
         ReLU(heapX);
         // then
@@ -62,11 +69,21 @@ public class NeuralNetworkNativeOpsTest {
     }
 
     @Test
-    public void testDirectFloatBuffersReLU() {
+    public void shouldReLUwithDirectFloatBuffers() {
         // when
         ReLU(directX);
         // then
         assertArrayEquals(expectedReLUx, getArrayFrom(directX), MAX_ERROR);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldReLUUnderflowThrow() {
+        ReLU(heapX, -1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldReLUOverflowThrow() {
+        ReLU(heapX, heapX.limit() + 1);
     }
 
     @Test
@@ -93,8 +110,26 @@ public class NeuralNetworkNativeOpsTest {
         assertArrayEquals(expectedELUx2, getArrayFrom(directX), MAX_ERROR);
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldELUUnderflowThrow() {
+        ELU(heapX, -1, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldELUOverflowThrow() {
+        ELU(heapX, heapX.limit() + 1, 0);
+    }
+
     @Test
-    public void testHeapFloatBuffersGemv() {
+    public void shouldMultiplyMatrixByVectorWithHeapFloatBuffers() {
+        // when
+        gemv(heapA, heapX, heapY, 1, heapY.limit());
+        // then
+        assertArrayEquals(expectedAbyFirstValXplusY, heapY.array(), MAX_ERROR);
+    }
+
+    @Test
+    public void shouldMultiplyMatrixByVectorWithHeapFloatBuffersSizeless() {
         // when
         gemv(heapA, heapX, heapY);
         // then
@@ -102,15 +137,33 @@ public class NeuralNetworkNativeOpsTest {
     }
 
     @Test
-    public void testDirectFloatBuffersGemv() {
+    public void shouldMultiplyMatrixByVectorWithDirectFloatBuffers() {
         // when
         gemv(directA, directX, directY);
         // then
         assertArrayEquals(expectedAbyXplusY, getArrayFrom(directY), MAX_ERROR);
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldGemvUnderflowThrow() {
+        gemv(directA, directX, directY, -1, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldGemvOverflowThrow() {
+        gemv(heapA, heapX, heapY, 1, heapY.limit() + 1);
+    }
+
     @Test
-    public void testHeapFloatBuffersLinearForward() {
+    public void shouldHeapFloatBuffersLinearForward() {
+        // when
+        linearForward(NO_TRANSPOSE, heapA, heapY, heapX, heapOutput, 1, heapY.limit());
+        // then
+        assertArrayEquals(expectedAbyFirstValXplusY, heapOutput.array(), MAX_ERROR);
+    }
+
+    @Test
+    public void shouldHeapFloatBuffersLinearForwardSizeless() {
         // when
         linearForward(NO_TRANSPOSE, heapA, heapY, heapX, heapOutput);
         // then
@@ -118,16 +171,57 @@ public class NeuralNetworkNativeOpsTest {
     }
 
     @Test
-    public void testDirectFloatBuffersLinearForward() {
+    public void shouldHeapFloatBuffersLinearForwardSizelessTransposed() {
+        // when
+        linearForward(TRANSPOSE, heapA, heapY, heapX, heapOutput);
+        // then
+        assertArrayEquals(expectedTransposedAbyXplusY, heapOutput.array(), MAX_ERROR);
+    }
+
+    @Test
+    public void shouldDirectFloatBuffersLinearForward() {
         // when
         linearForward(NO_TRANSPOSE, directA, directY, directX, directOutput);
         // then
         assertArrayEquals(expectedAbyXplusY, getArrayFrom(directOutput), MAX_ERROR);
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldLinearForwardUnderflowThrow() {
+        linearForward(NO_TRANSPOSE, directA, directY, directX, directOutput, -1, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldLinearForwardOverflowThrow() {
+        linearForward(NO_TRANSPOSE, heapA, heapY, heapX, heapOutput, heapX.limit() + 1, 0);
+    }
+
     @Test
     public void shouldMultiplyTwoMatrices() {
-        //given
+        // given
+        FloatBuffer a = matrixFB(
+                1f / 3, 1, -1,
+                2, 4, -1); // ignored row
+        FloatBuffer b = matrixFB(
+                1f / 5, 1,
+                7, 49,
+                -2, -3);
+        FloatBuffer c = matrixFB(
+                0, 0);
+
+        // when
+        gemm(a, b, c, 1, 2, 3);
+
+        // then
+        assertArrayEquals(
+                matrix(9.06666666f, 52.33333333f),
+                getArrayFrom(c),
+                MAX_ERROR);
+    }
+
+    @Test
+    public void shouldMultiplyTwoMatricesSizeless() {
+        // given
         FloatBuffer a = matrixFB(
                 1f / 3, 1, -1,
                 2, 4, -1);
@@ -135,13 +229,14 @@ public class NeuralNetworkNativeOpsTest {
                 1f / 5, 1,
                 7, 49,
                 -2, -3);
-        FloatBuffer c = FloatBuffer.wrap(new float[] { 0, 0,
-                0, 0 });
+        FloatBuffer c = matrixFB(
+                0, 0,
+                0, 0);
 
-        //when
-        NeuralNetworkNativeOps.gemm(a, b, c, 2, 2, 3);
+        // when
+        gemm(a, b, c, 2, 2, 3);
 
-        //then
+        // then
         assertArrayEquals(
                 matrix(9.06666666f, 52.33333333f,
                         30.4000f, 201.00000f),
@@ -149,9 +244,19 @@ public class NeuralNetworkNativeOpsTest {
                 MAX_ERROR);
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldMultiplyTwoMatricesUnderflowThrow() {
+        gemm(heapA, heapA, heapX, -1, 0, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldMultiplyTwoMatricesOverflowThrow() {
+        gemm(heapA, heapA, heapX, heapA.limit() + 1, 1, 0);
+    }
+
     @Test
     public void shouldForwardLinearOnBatch() {
-        //given
+        // given
         FloatBuffer weights = matrixFB(
                 1f / 3, 1, 3,
                 2, 4, 9);
@@ -170,10 +275,10 @@ public class NeuralNetworkNativeOpsTest {
                 7, 8, 7,
                 9, 10, -1);
 
-        //when
-        NeuralNetworkNativeOps.linearBatchForward(NO_TRANSPOSE, weights, biases, input, output, 2, 3, 5);
+        // when
+        linearBatchForward(NO_TRANSPOSE, weights, biases, input, output, 2, 3, 5);
 
-        //then
+        // then
         assertArrayEquals(
                 matrix(31f / 15 + 0.1f, 4.4f, 9.3f,
                         301f / 3 + 0.1f, 203.2f, 461.7f,
@@ -186,7 +291,7 @@ public class NeuralNetworkNativeOpsTest {
 
     @Test
     public void shouldForwardLinearOnBatchWithTranspose() {
-        //given
+        // given
         FloatBuffer weights = matrixFB(
                 1f / 3, 2,
                 1, 4,
@@ -206,10 +311,10 @@ public class NeuralNetworkNativeOpsTest {
                 7, 8, 7,
                 9, 10, -1);
 
-        //when
-        NeuralNetworkNativeOps.linearBatchForward(TRANSPOSE, weights, biases, input, output, 2, 3, 5);
+        // when
+        linearBatchForward(TRANSPOSE, weights, biases, input, output, 2, 3, 5);
 
-        //then
+        // then
         assertArrayEquals(
                 matrix(31f / 15 + 0.1f, 4.4f, 9.3f,
                         301f / 3 + 0.1f, 203.2f, 461.7f,
@@ -220,45 +325,14 @@ public class NeuralNetworkNativeOpsTest {
                 MAX_ERROR);
     }
 
-    @Test
-    public void shouldForwardLinear() {
-        //given
-        FloatBuffer weights = matrixFB(
-                1f / 3, 2,
-                1, 4,
-                3, 9);
-        FloatBuffer biases = matrixFB(0.1f, 0.2f, -0.3f); //vector
-        FloatBuffer input = matrixFB(1f / 5, 1); //vector
-        FloatBuffer output = matrixFB(1, 2, 3); //vector
-
-        //when
-        NeuralNetworkNativeOps.linearForward(NO_TRANSPOSE, weights, biases, input, output);
-
-        //then
-        assertArrayEquals(
-                matrix(31f / 15 + 0.1f, 4.4f, 9.3f),
-                getArrayFrom(output),
-                MAX_ERROR);
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldForwardLinearOnBatchUnderflowThrow() {
+        linearBatchForward(NO_TRANSPOSE, heapA, heapY, heapX, heapY, -1, 0, 0);
     }
 
-    @Test
-    public void shouldForwardLinearWithTranspose() {
-        //given
-        FloatBuffer weights = matrixFB(
-                1f / 3, 1, 3,
-                2, 4, 9);
-        FloatBuffer biases = matrixFB(0.1f, 0.2f, -0.3f); //vector
-        FloatBuffer input = matrixFB(1f / 5, 1); //vector
-        FloatBuffer output = matrixFB(1, 2, 3); //vector
-
-        //when
-        NeuralNetworkNativeOps.linearForward(TRANSPOSE, weights, biases, input, output);
-
-        //then
-        assertArrayEquals(
-                matrix(31f / 15 + 0.1f, 4.4f, 9.3f),
-                getArrayFrom(output),
-                MAX_ERROR);
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldForwardLinearOnBatchOverflowThrow() {
+        linearBatchForward(NO_TRANSPOSE, heapA, heapY, heapX, heapY, heapA.limit() + 1, 1, 0);
     }
 
     private float[] matrix(float... values) {


### PR DESCRIPTION
- [x] Added safety checks to avoid out of bunds memory access
- [x] tests for thos safety guards added
- [x] `TRANSFORM` flags as enums
- [x] documentation corrections and enhancements
- [x] "sizeless" gemm API removal
- [x] native test removal